### PR TITLE
[7/20]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
 			<scope>system</scope>
 			<systemPath>${project.basedir}/lib/balana-util.jar</systemPath>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.1</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/src/main/java/httpServer/PDPServer.java
+++ b/src/main/java/httpServer/PDPServer.java
@@ -1,5 +1,8 @@
 package httpServer;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -35,34 +38,55 @@ public class PDPServer {
 
     private static class EvaluateHandler implements HttpHandler {
 
+        Gson gson = new GsonBuilder().create();
+
         @Override
-        public void handle(HttpExchange httpExchange) throws IOException {
+        public void handle(HttpExchange httpExchange)  {
             InputStream inputStream = httpExchange.getRequestBody();
-            String inputString = read(inputStream);
-            String response = evaluateRequest(inputString);
-            if (response != null) {
-                httpExchange.sendResponseHeaders(200, response.getBytes().length);
-                OutputStream os = httpExchange.getResponseBody();
-                os.write(response.getBytes());
-                os.close();
-            } else {
-                handleError(httpExchange, "Not valid request");
+            String inputString = null;
+            try {
+                inputString = read(inputStream);
+                JsonObject inputJson = gson.fromJson(inputString, JsonObject.class);
+                String requestBody = inputJson.get("body").getAsString();
+                //TODO: policiesId 를 이용해 policies 찾는 과정을 고민해야함
+                String policiesId = null;
+                if (inputJson.get("policyId") != null)
+                    policiesId = inputJson.get("policyId").getAsString();
+                String sep = File.separator;
+                String policies = (new File(".")).getCanonicalPath() + sep + "resources" + sep + "IntentConflictExamplePolicies";
+
+                //TODO: attribute set 을 어떻게 가져올 건지에 대한 고민 필요
+                String response = evaluateRequest(requestBody, policies);
+                if (response != null) {
+                    httpExchange.sendResponseHeaders(200, response.getBytes().length);
+                    OutputStream os = httpExchange.getResponseBody();
+                    os.write(response.getBytes());
+                    os.close();
+                } else {
+                    handleError(httpExchange, "Not valid request");
+                }
+
+            } catch (IOException e) {
+                e.printStackTrace();
             }
+
+
+
         }
 
         private String read(InputStream inputStream) throws IOException {
             StringBuffer sb = new StringBuffer();
             byte[] b = new byte[4096];
-            while(inputStream.available() != 0) {
+            while (inputStream.available() != 0) {
                 int n = inputStream.read(b);
                 sb.append(new String(b, 0, n));
             }
             return sb.toString();
         }
 
-        private String evaluateRequest(String request) {
+        private String evaluateRequest(String request, String ...policiesLoc) {
             if (request.equals("")) return null;
-            String response = pdpInterface.evaluate(request);
+            String response = pdpInterface.evaluate(request, policiesLoc);
             return response;
         }
 


### PR DESCRIPTION
json parser library로  gson 추가
balana 객체 없이 PDPConfig  객체 생성하여 PDP 객체 생성 - balana가 pdpconfig 객체를 하나만 가지고 있어 생기는 동기화 문제 제거
evaluate 통신 방식(확정 아님):
Content-Type : application/json
{
    policyId : 1,
    body : XACML Request code,
}