### PR TITLE
[08/03] 샘플 정책 수정

### DIFF
--- a/resources/IntentConflictExamplePolicies/conflict-family-policy.xml
+++ b/resources/IntentConflictExamplePolicies/conflict-family-policy.xml
@@ -1,14 +1,8 @@
 <Policy xmlns="urn:oasis:names:tc:xacml:3.0:core:schema:wd-17" PolicyId="ConflictFamilyPolicy"
-        RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-overrides" Version="1.0">
+        RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-unless-permit" Version="1.0">
     <Target>
         <AnyOf>
             <AllOf>
-                <!--<Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">-->
-                    <!--<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">family</AttributeValue>-->
-                    <!--<AttributeDesignator AttributeId="http://selab.hanayng.ac.kr/id/role"-->
-                                         <!--Category="http://selab.hanayng.ac.kr/category"-->
-                                         <!--DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>-->
-                <!--</Match>-->
                 <Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
                     <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">car</AttributeValue>
                     <AttributeDesignator AttributeId="urn:oasis:names:tc:xacml:1.0:resource:resource-id"
@@ -17,14 +11,16 @@
                 </Match>
             </AllOf>
         </AnyOf>
-        <Subjects>
-            <Attribute AttributeID="http://selab.hanayng.ac.kr/id/role"
-                       DataType="http://www.w3.org/2001/XMLSchema#string">
-                <AttributeValue>family</AttributeValue>
-            </Attribute>
-        </Subjects>
     </Target>
     <Rule RuleId="permit-rule" Effect="Permit">
+        <Condition>
+            <Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-is-in">
+                <AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">family</AttributeValue>
+                <AttributeDesignator AttributeId="http://selab.hanayng.ac.kr/id/role"
+                                     Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject"
+                                     DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
+            </Apply>
+        </Condition>
         <AdviceExpressions>
             <AdviceExpression AdviceId="permit-time-range-advice2" AppliesTo="Permit">
                 <AttributeAssignmentExpression AttributeId="urn:oasis:names:tc:xacml:2.0:example:attribute:text">

--- a/resources/IntentConflictExamplePolicies/conflict-son-policy.xml
+++ b/resources/IntentConflictExamplePolicies/conflict-son-policy.xml
@@ -4,7 +4,7 @@
 			<AllOf>
 				<Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
 					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">son</AttributeValue>
-					<AttributeDesignator AttributeId="http://selab.hanayng.ac.kr/id/role" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
+					<AttributeDesignator AttributeId="http://selab.hanayng.ac.kr/id/role" Category="urn:oasis:names:tc:xacml:1.0:subject-category:access-subject" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
 				</Match>
 				<Match MatchId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
 					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">car</AttributeValue>
@@ -12,12 +12,6 @@
 				</Match>
 			</AllOf>
 		</AnyOf>
-		<Subjects>
-			<Attribute AttributeID="http://selab.hanayng.ac.kr/id/role"
-					   DataType="http://www.w3.org/2001/XMLSchema#string">
-				<AttributeValue>son</AttributeValue>
-			</Attribute>
-		</Subjects>
 	</Target>
 	<Rule Effect="Deny" RuleId="start-car-time">
 		<Condition>
@@ -42,13 +36,13 @@
 					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">Deny: Son can start car only between 9 and 16 o'clock.</AttributeValue>
 				</AttributeAssignmentExpression>
 			</AdviceExpression>
-		</AdviceExpressions>	
+		</AdviceExpressions>
 	</Rule>
 	<Rule Effect="Deny" RuleId="parent-assist">
 		<Condition>
 			<Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:not">
 				<Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-equal">
-					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">fred</AttributeValue>
+					<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">father</AttributeValue>
 					<Apply FunctionId="urn:oasis:names:tc:xacml:1.0:function:string-one-and-only">
 						<AttributeDesignator AttributeId="http://selab.hanyang.ac.kr/id/assist" Category="http://selab.hanyang.ac.kr/category" DataType="http://www.w3.org/2001/XMLSchema#string" MustBePresent="true"/>
 					</Apply>

--- a/resources/config.xml
+++ b/resources/config.xml
@@ -1,8 +1,6 @@
 <config defaultPDP="pdp" defaultAttributeFactory="attr"
         defaultCombiningAlgFactory="comb" defaultFunctionFactory="func">
     <pdp name="pdp">
-        <attributeFinderModule class="org.wso2.balana.finder.impl.CurrentEnvModule"/>
-        <attributeFinderModule class="org.wso2.balana.finder.impl.SelectorModule"/>
         <policyFinderModule class="org.wso2.balana.finder.impl.FileBasedPolicyFinderModule">
             <set>
                 <string>resources/IntentConflictExamplePolicies</string>
@@ -21,6 +19,7 @@
 
     <attributeFactory name="attr" useStandardDatatypes="true"/>
     <functionFactory name="func" useStandardFunctions="true"/>
-    <combiningAlgFactory name="comb" useStandardAlgorithms="true"></combiningAlgFactory>
+    <combiningAlgFactory name="comb" useStandardAlgorithms="true"/>
 
 </config>
+

--- a/resources/request/example-request
+++ b/resources/request/example-request
@@ -2,32 +2,31 @@
 	"pepId": "pdp",
 	"attributeList": ["http://selab.hanyang.ac.kr/category"],
 	"body":"
-    <Request xmlns=\"urn:oasis:names:tc:xacml:3.0:core:schema:wd-17\" CombinedDecision=\"true\" ReturnPolicyIdList=\"false\">
+	<Request xmlns=\"urn:oasis:names:tc:xacml:3.0:core:schema:wd-17\" CombinedDecision=\"true\" ReturnPolicyIdList=\"false\">
         <Attributes Category=\"urn:oasis:names:tc:xacml:3.0:attribute-category:action\">
             <Attribute AttributeId=\"urn:oasis:names:tc:xacml:1.0:action:action-id\" IncludeInResult=\"false\">
                 <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">start</AttributeValue>
             </Attribute>
         </Attributes>
-        <Subject>
+        <Attributes Category=\"urn:oasis:names:tc:xacml:1.0:subject-category:access-subject\">
             <Attribute AttributeId=\"http://selab.hanayng.ac.kr/id/role\" IncludeInResult=\"false\">
-                <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">father</AttributeValue>
-            </Attribute>
-            <Attribute AttributeId=\"http://selab.hanayng.ac.kr/id/role\" IncludeInResult=\"false\">
+                <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">son</AttributeValue>
                 <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">family</AttributeValue>
             </Attribute>
-        </Subject>
+        </Attributes>
         <Attributes Category=\"urn:oasis:names:tc:xacml:3.0:attribute-category:resource\">
             <Attribute AttributeId=\"urn:oasis:names:tc:xacml:1.0:resource:resource-id\" IncludeInResult=\"false\">
                 <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">car</AttributeValue>
             </Attribute>
         </Attributes>
         <Attributes Category=\"http://selab.hanyang.ac.kr/category\">
-            <Attribute AttributeId=\"http://selab.hanyang.ac.kr/id/assist\" IncludeInResult=\"false\">
-                <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">father</AttributeValue>
-            </Attribute>
-            <Attribute AttributeId=\"http://selab.hanyang.ac.kr/id/hour\" IncludeInResult=\"false\">
-                <AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#integer\">12</AttributeValue>
-            </Attribute>
-        </Attributes>
-    </Request>"
+	    	<Attribute AttributeId=\"http://selab.hanyang.ac.kr/id/assist\" IncludeInResult=\"false\">
+	    		<AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#string\">father</AttributeValue>
+	    	</Attribute>
+	    	<Attribute AttributeId=\"http://selab.hanyang.ac.kr/id/hour\" IncludeInResult=\"false\">
+	    		<AttributeValue DataType=\"http://www.w3.org/2001/XMLSchema#integer\">12</AttributeValue>
+	    	</Attribute>
+	    </Attributes>
+    </Request>
+    "
 }

--- a/src/main/java/httpServer/PDPInterface.java
+++ b/src/main/java/httpServer/PDPInterface.java
@@ -4,17 +4,8 @@ import org.wso2.balana.*;
 import org.wso2.balana.attr.AttributeFactory;
 import org.wso2.balana.combine.CombiningAlgFactory;
 import org.wso2.balana.cond.FunctionFactoryProxy;
-import org.wso2.balana.finder.AttributeFinder;
-import org.wso2.balana.finder.PolicyFinder;
-import org.wso2.balana.finder.impl.CurrentEnvModule;
-import org.wso2.balana.finder.impl.FileBasedPolicyFinderModule;
-import org.wso2.balana.finder.impl.SelectorModule;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 
 public class PDPInterface {
 


### PR DESCRIPTION
기존 정책에 있어서 family가 아니면서 son인 경우 conflict-family-policy의 target에 적용되지 않아 Deny 혹은 NA가 나와야하지만 conflict-son-policy의 결과값이 Permit임에 따라 최종적으로 Permit이 반환되는 문제가 있었습니다.
이를 해결하기 위해 우선 conflict-family-policy가 car에 대한 요청을 모두 target으로 받아드리고 family가 아닐 경우(Rule의 Condition으로 작성) Deny를 반환하도록 변경하였습니다.
또한 multi attribute의 경우, string-is-in 함수를 이용하여 비교할 수 있도록 하였습니다.

Subject 속성을 쓰지 않더라도 Attribute id만 같으면 multi attribute로 작성할 수 있기 때문에 기존의 Match 방법을 다시 사용하고 Request와 정책에서 모두 Subject속성을 삭제하였습니다.